### PR TITLE
install lintr and languageserver on start if not installed

### DIFF
--- a/src/r.rs
+++ b/src/r.rs
@@ -17,12 +17,21 @@ impl zed::Extension for RExtension {
             return Err("R not available".to_string());
         };
 
+        let install_packages = r#"
+            if (!requireNamespace("languageserver", quietly = TRUE)) {
+                install.packages("languageserver", repos = "https://cloud.r-project.org/")
+            }
+            if (!requireNamespace("lintr", quietly = TRUE)) {
+                install.packages("lintr", repos = "https://cloud.r-project.org/")
+            }
+        "#;
+
         Ok(zed::Command {
             command: r_path.to_string(),
             args: vec![
                 "--slave".to_string(),
                 "-e".to_string(),
-                "languageserver::run()".to_string(),
+                format!("{install_packages}\nlanguageserver::run()"),
             ],
             env: Default::default(),
         })


### PR DESCRIPTION
Installs `languageserver` and `lintr` during startup to ease first use of this extension.