### PR TITLE
Improve outline, autocomplete, auto-closing, and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .DS_Store
 *.R
+grammars
+target
+Cargo.lock
+extension.wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ path = "src/r.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.0.6"
+zed_extension_api = "0.2.0"

--- a/languages/r/brackets.scm
+++ b/languages/r/brackets.scm
@@ -1,0 +1,3 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)

--- a/languages/r/config.toml
+++ b/languages/r/config.toml
@@ -2,7 +2,7 @@ name = "R"
 grammar = "r"
 path_suffixes = ["r", "R"]
 line_comments = ["# ", "#"]
-autoclose_before = "=}])"
+autoclose_before = "$@=,}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },

--- a/languages/r/config.toml
+++ b/languages/r/config.toml
@@ -1,10 +1,11 @@
 name = "R"
 grammar = "r"
 path_suffixes = ["r", "R"]
-line_comments = ["# "]
-autoclose_before = ""
+line_comments = ["# ", "#"]
+autoclose_before = "=}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
     { start = "(", end = ")", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = [
         "comment",
@@ -16,3 +17,4 @@ brackets = [
     ] },
 ]
 collapsed_placeholder = "# ..."
+word_characters = ["."]

--- a/languages/r/config.toml
+++ b/languages/r/config.toml
@@ -1,7 +1,7 @@
 name = "R"
 grammar = "r"
 path_suffixes = ["r", "R"]
-line_comments = ["# ", "#"]
+line_comments = ["#' ", "# ", "#"]
 autoclose_before = "$@=,}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -154,3 +154,7 @@
 ; roxygen
 ((comment) @documentation
     (#match? @documentation "^#'"))
+
+; jupyter cell tag
+((comment) @operator
+    (#match? @operator "^#\\s?%%"))

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -150,3 +150,7 @@
 
 ; Error
 (ERROR) @error
+
+; roxygen
+((comment) @documentation
+    (#match? @documentation "^#'"))

--- a/languages/r/outline.scm
+++ b/languages/r/outline.scm
@@ -7,7 +7,19 @@
    name: (identifier) @name
    value: (_) @value) @item
 
-; `for` statement
+(right_assignment
+    value: (_) @value
+    name: (identifier) @name) @item
+
+(super_assignment
+    name: (identifier) @name
+    value: (_) @value) @item
+
+(super_right_assignment
+    value: (_) @value
+    name: (identifier) @name) @item
+
+; `for` loop
 (for
   "(" (identifier) @name
       "in" (_) @value

--- a/languages/r/outline.scm
+++ b/languages/r/outline.scm
@@ -1,7 +1,21 @@
+; Variables
 (left_assignment
    name: (identifier) @name
-   value: (function_definition) @value) @item
+   value: (_) @value) @item
 
 (equals_assignment
    name: (identifier) @name
-   value: (function_definition) @value) @item
+   value: (_) @value) @item
+
+; `for` statement
+(for
+  "(" (identifier) @name
+      "in" (_) @value
+  ")"
+  body: (_)) @item
+
+; Jupyter cell tag
+(
+  (comment) @name
+  (#match? @name "^#\\s?%%")
+) @item


### PR DESCRIPTION
Hi, dear author,  

This PR addresses several issues affecting user experience:  

1. **Outline**: The outline can display all variables defined by assignment operators and `for` loops, and Jupyter cell tags with highlights (`#%%` or `# %%`).
2. **Roxygen**: Added the roxygen comment (`#'`), so that we can easily type it on `enter`. Fixed #10 . Also added highlights for Roxygen documentation.
3. **Autocomplete for functions with dots**: Functions like `as.data.frame()` now complete correctly instead of erroneous suggestions like `as.as.data.frame()`.  
4. **Auto-closing behavior**: The `'` and `"` characters now properly auto-close inside brackets.
5. **REPL usability**: Added a line comment (`#` without a space) to prevent issues before file formatting (When I type `#%%`, REPL will fail).
6. **Misc**: Added a `brackets.scm` file and upgraded `zed_extension_api` to v0.2.0 (though no visible changes).  

I have tested these changes on my M1 Pro MacBook, and everything runs smoothly.  

This is my first PR, so please let me know if anything needs improvement. Happy to make adjustments!  