### PR TITLE
Fix hotkey `cmd-/`

### DIFF
--- a/languages/r/config.toml
+++ b/languages/r/config.toml
@@ -1,7 +1,7 @@
 name = "R"
 grammar = "r"
 path_suffixes = ["r", "R"]
-line_comments = ["#' ", "# ", "#"]
+line_comments = ["# ", "#' ", "#"]
 autoclose_before = "$@=,}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -116,29 +116,16 @@
 (call function: (identifier) @function)
 
 (call function: (identifier) @keyword
-     (#any-of? @keyword "library" "require" "source" "return" "stop" "try" "tryCatch"))
+  (#any-of? @keyword "library" "require" "source" "return" "stop" "try" "tryCatch"))
 
 [
   (function_definition)
   (lambda_function)
 ] @function.outer
 
-(function_definition
-  "function" @keyword
-  [
-    (call)
-    (binary)
-    (brace_list)
-  ] @function.inner) @function.outer
+(function_definition "function" @keyword)
 
-(lambda_function
-  "\\" @keyword
-  [
-    (call)
-    (binary)
-    (brace_list)
-  ] @function.inner
-) @function.outer
+(lambda_function "\\" @keyword)
 
 (default_argument name: (identifier) @parameter)
 

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -3,11 +3,11 @@
 
 ; Literals
 
-(integer) @number
-
-(float) @float
-
-(complex) @number
+[
+  (integer)
+  (float)
+  (complex)
+] @number
 
 (string) @string
 (string (escape_sequence) @string.escape)

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -98,13 +98,13 @@
   "if"
   "else"
   "switch"
-] @conditional
+] @keyword
 
 [
   "while"
   "repeat"
   "for"
-] @repeat
+] @keyword
 
 [
   (true)
@@ -112,8 +112,11 @@
 ] @boolean
 
 ; funcs
-"function" @keyword.function
+; "function" @keyword.function
 (call function: (identifier) @function)
+
+(call function: (identifier) @keyword
+     (#any-of? @keyword "library" "require" "source" "return" "stop" "try" "tryCatch"))
 
 [
   (function_definition)
@@ -121,6 +124,7 @@
 ] @function.outer
 
 (function_definition
+  "function" @keyword
   [
     (call)
     (binary)
@@ -128,6 +132,7 @@
   ] @function.inner) @function.outer
 
 (lambda_function
+  "\\" @keyword
   [
     (call)
     (binary)


### PR DESCRIPTION
The comment hotkey `cmd-/` will correctly type to `#`, not `#'`.