### PR TITLE
Changing captures for better theming

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "r"
 name = "R"
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Owen Smith <owen8461@protonmail.com>"]
 description = "R languange support"

--- a/languages/r/config.toml
+++ b/languages/r/config.toml
@@ -1,7 +1,7 @@
 name = "R"
 grammar = "r"
 path_suffixes = ["r", "R"]
-line_comments = ["#' ", "# ", "#"]
+line_comments = ["# ", "#' ", "#"]
 autoclose_before = "$@=,}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -106,28 +106,20 @@
 ] @boolean
 
 ; funcs
-"function" @keyword.function
+;"function" @keyword.function
 (call function: (identifier) @function)
+
+(call function: (identifier) @keyword
+  (#any-of? @keyword "library" "require" "source" "return" "stop" "try" "tryCatch"))
 
 [
   (function_definition)
   (lambda_function)
 ] @function.outer
 
-(function_definition
-  [
-    (call)
-    (binary)
-    (brace_list)
-  ] @function.inner) @function.outer
+(function_definition "function" @keyword)
 
-(lambda_function
-  [
-    (call)
-    (binary)
-    (brace_list)
-  ] @function.inner
-) @function.outer
+(lambda_function "\\" @keyword)
 
 (default_argument name: (identifier) @parameter)
 

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -138,10 +138,10 @@
 (namespace_get_internal function: (identifier) @function)
 
 (namespace_get
-    namespace: (identifier) @name
+    namespace: (identifier) @type
     "::" @operator)
 (namespace_get_internal
-    namespace: (identifier) @name
+    namespace: (identifier) @type
     ":::" @operator)
 
 ; Error

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -82,6 +82,14 @@
 
 [
  "in"
+ "if"
+ "else"
+ "switch"
+ "stop"
+ "tryCatch"
+ "while"
+ "repeat"
+ "for"
  (dots)
  (break)
  (next)
@@ -93,18 +101,6 @@
   (na)
   (null)
 ] @type.builtin
-
-[
-  "if"
-  "else"
-  "switch"
-] @conditional
-
-[
-  "while"
-  "repeat"
-  "for"
-] @repeat
 
 [
   (true)

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -3,11 +3,11 @@
 
 ; Literals
 
-(integer) @number
-
-(float) @float
-
-(complex) @number
+[
+  (integer)
+  (float)
+  (complex)
+] @number
 
 (string) @string
 (string (escape_sequence) @string.escape)

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -85,8 +85,6 @@
  "if"
  "else"
  "switch"
- "stop"
- "tryCatch"
  "while"
  "repeat"
  "for"
@@ -100,7 +98,7 @@
   (nan)
   (na)
   (null)
-] @type.builtin
+] @variable.special
 
 [
   (true)


### PR DESCRIPTION
* Now libraries are highlighted in most themes (`@type` instead of `@name`)
* The nan, na and null are now `@variable.special`
* `@repeat` and `@conditional` are better put in `@keyword`

Problems I faced:
* ~~Adding `stop` and `tryCatch` to `@keyword` somehow breaks the extension~~ Done by @lict99 

What I plan to add but couldn't due to errors:
* ~~Add `function` and `return` to `@keyword` alongside other closures like `library` etc,...~~ Done by @lict99 
* Add `T` and `F` in `@boolean`. 
* Try to find a way around misc files in R like `.Rmd`, `DESCRIPTION` and `NAMESPACE`

I do have more ideas on my mind, @ocsmit let me know if you're up to *really* upgrade this extension!

**Note**: All my work is based on the Zed documentation [here](https://zed.dev/docs/extensions/languages#syntax-highlighting)