### PR TITLE
Update grammars.r version + tweak highlighting

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -1,6 +1,6 @@
 id = "r"
 name = "R"
-version = "0.0.8"
+version = "0.1.0"
 schema_version = 1
 authors = [
     "Owen Smith <owen8461@protonmail.com>",
@@ -12,7 +12,7 @@ repository = "https://github.com/ocsmit/zed-r"
 
 [grammars.r]
 repository = "https://github.com/r-lib/tree-sitter-r"
-commit = "c55f8b4dfaa32c80ddef6c0ac0e79b05cb0cbf57"
+commit = "a0d3e3307489c3ca54da8c7b5b4e0c5f5fd6953a"
 
 [language_servers.r_language_server]
 name = "r lsp"

--- a/languages/r/highlights.scm
+++ b/languages/r/highlights.scm
@@ -1,141 +1,125 @@
 ; highlights.scm
 
-
 ; Literals
 
-[
-  (integer)
-  (float)
-  (complex)
-] @number
+(integer) @number
+(float) @number
+(complex) @number
 
 (string) @string
-(string (escape_sequence) @string.escape)
+(string (string_content (escape_sequence) @string.escape))
+
+; Comments
 
 (comment) @comment
 
-(identifier) @variable
-
-(formal_parameters (identifier) @parameter)
-(formal_parameters (default_parameter (identifier) @parameter))
-
 ; Operators
+
 [
- "="
- "<-"
- "<<-"
- "->>"
- "->"
+  "?" ":=" "=" "<-" "<<-" "->" "->>"
+  "~" "|>" "||" "|" "&&" "&"
+  "<" "<=" ">" ">=" "==" "!="
+  "+" "-" "*" "/" "::" ":::"
+  "**" "^" "$" "@" ":" "!"
+  "special"
 ] @operator
 
-(unary operator: [
-  "-"
-  "+"
-  "!"
-  "~"
-] @operator)
-
-(binary operator: [
-  "-"
-  "+"
-  "*"
-  "/"
-  "^"
-  "<"
-  ">"
-  "<="
-  ">="
-  "=="
-  "!="
-  "||"
-  "|"
-  "&&"
-  "&"
-  ":"
-  "~"
-] @operator)
+; Punctuation
 
 [
-  "|>"
-  (special)
-] @operator
-
-(lambda_function "\\" @operator)
-
-[
- "("
- ")"
- "["
- "]"
- "{"
- "}"
+  "("  ")"
+  "{"  "}"
+  "["  "]"
+  "[[" "]]"
 ] @punctuation.bracket
 
-(dollar "$" @operator)
-(slot "@" @operator)
+(comma) @punctuation.delimiter
 
-(subset2
- [
-  "[["
-  "]]"
- ] @punctuation.bracket)
+; Variables
+
+(identifier) @variable
+
+; Functions
+
+(binary_operator
+    lhs: (identifier) @function
+    operator: "<-"
+    rhs: (function_definition)
+)
+
+(binary_operator
+    lhs: (identifier) @function
+    operator: "="
+    rhs: (function_definition)
+)
+
+; Calls
+
+(call function: (identifier) @function)
+
+; Parameters
+
+(parameters (parameter name: (identifier) @variable.parameter))
+(arguments (argument name: (identifier) @variable.parameter))
+
+; Namespace
+
+(namespace_operator lhs: (identifier) @type)
+
+(call
+    function: (namespace_operator rhs: (identifier) @function)
+)(call function: (identifier) @function)
+
+
+; Keywords
+
+(function_definition name: "function" @keyword.function)
+(function_definition name: "\\" @keyword.function)
 
 [
- "in"
- "if"
- "else"
- "switch"
- "while"
- "repeat"
- "for"
- (dots)
- (break)
- (next)
- (inf)
+  "in"
+  (return)
+  (next)
+  (break)
+   "if"
+   "else"
+   ; "switch"
+   "while"
+   "repeat"
+   "for"
 ] @keyword
 
-[
-  (nan)
-  (na)
-  (null)
-] @variable.special
+; [
+;   "if"
+;   "else"
+; ] @conditional
+
+; [
+;   "while"
+;   "repeat"
+;   "for"
+; ] @repeat
 
 [
   (true)
   (false)
 ] @boolean
 
-; funcs
-;"function" @keyword.function
-(call function: (identifier) @function)
+[
+  (null)
+  (inf)
+  (nan)
+  (na)
+  (dots)
+  (dot_dot_i)
+] @constant.builtin
+
+; Error
+
+(ERROR) @error
 
 (call function: (identifier) @keyword
   (#any-of? @keyword "library" "require" "source" "return" "stop" "try" "tryCatch"))
-
-[
-  (function_definition)
-  (lambda_function)
-] @function.outer
-
-(function_definition "function" @keyword)
-
-(lambda_function "\\" @keyword)
-
-(default_argument name: (identifier) @parameter)
-
-; namespace calls
-(namespace_get function: (identifier) @function)
-(namespace_get_internal function: (identifier) @function)
-
-(namespace_get
-    namespace: (identifier) @type
-    "::" @operator)
-(namespace_get_internal
-    namespace: (identifier) @type
-    ":::" @operator)
-
-; Error
-(ERROR) @error
 
 ; roxygen
 ((comment) @documentation

--- a/languages/r/locals.scm
+++ b/languages/r/locals.scm
@@ -1,0 +1,18 @@
+; locals.scm
+
+(function_definition) @local.scope
+
+(argument  name: (identifier) @local.definition)
+(parameter name: (identifier) @local.definition)
+
+(binary_operator
+    lhs: (identifier) @local.definition
+    operator: "<-")
+(binary_operator
+    lhs: (identifier) @local.definition
+    operator: "=")
+(binary_operator
+    operator: "->"
+    rhs: (identifier) @local.definition)
+
+(identifier) @local.reference

--- a/languages/r/outline.scm
+++ b/languages/r/outline.scm
@@ -1,30 +1,30 @@
-; Variables
-(left_assignment
-   name: (identifier) @name
-   value: (_) @value) @item
+; ; Variables
+; (left_assignment
+;    name: (identifier) @name
+;    value: (_) @value) @item
 
-(equals_assignment
-   name: (identifier) @name
-   value: (_) @value) @item
+; (equals_assignment
+;    name: (identifier) @name
+;    value: (_) @value) @item
 
-(right_assignment
-    value: (_) @value
-    name: (identifier) @name) @item
+; (right_assignment
+;     value: (_) @value
+;     name: (identifier) @name) @item
 
-(super_assignment
-    name: (identifier) @name
-    value: (_) @value) @item
+; (super_assignment
+;     name: (identifier) @name
+;     value: (_) @value) @item
 
-(super_right_assignment
-    value: (_) @value
-    name: (identifier) @name) @item
+; (super_right_assignment
+;     value: (_) @value
+;     name: (identifier) @name) @item
 
-; `for` loop
-(for
-  "(" (identifier) @name
-      "in" (_) @value
-  ")"
-  body: (_)) @item
+; ; `for` loop
+; (for
+;   "(" (identifier) @name
+;       "in" (_) @value
+;   ")"
+;   body: (_)) @item
 
 ; Jupyter cell tag
 (

--- a/languages/r/outline.scm
+++ b/languages/r/outline.scm
@@ -1,30 +1,24 @@
-; ; Variables
-; (left_assignment
-;    name: (identifier) @name
-;    value: (_) @value) @item
+(binary_operator
+    lhs: (identifier) @name
+    operator: "<-"
+    rhs: (function_definition)
+) @definition.function
 
-; (equals_assignment
-;    name: (identifier) @name
-;    value: (_) @value) @item
+(binary_operator
+    lhs: (identifier) @name
+    operator: "="
+    rhs: (function_definition)
+) @definition.function
 
-; (right_assignment
-;     value: (_) @value
-;     name: (identifier) @name) @item
+(call
+    function: (identifier) @name
+) @reference.call
 
-; (super_assignment
-;     name: (identifier) @name
-;     value: (_) @value) @item
-
-; (super_right_assignment
-;     value: (_) @value
-;     name: (identifier) @name) @item
-
-; ; `for` loop
-; (for
-;   "(" (identifier) @name
-;       "in" (_) @value
-;   ")"
-;   body: (_)) @item
+(call
+    function: (namespace_operator
+        rhs: (identifier) @name
+    )
+) @reference.call
 
 ; Jupyter cell tag
 (

--- a/languages/r/outline.scm
+++ b/languages/r/outline.scm
@@ -1,27 +1,28 @@
+; Variables by assignment operators
 (binary_operator
     lhs: (identifier) @name
-    operator: "<-"
-    rhs: (function_definition)
-) @definition.function
+    operator: ["<-" "=" "<<-"]
+    rhs: (_)
+) @item
 
 (binary_operator
-    lhs: (identifier) @name
-    operator: "="
-    rhs: (function_definition)
-) @definition.function
+    lhs: (_)
+    operator: ["->" "->>"]
+    rhs: (identifier) @name
+) @item
 
-(call
-    function: (identifier) @name
-) @reference.call
-
-(call
-    function: (namespace_operator
-        rhs: (identifier) @name
-    )
-) @reference.call
+; Variables by `for` loop
+(for_statement
+  "for" @context
+  "(" @context
+  variable: (identifier) @name
+  "in" @context
+  sequence: (_) @context
+  ")" @context
+) @item
 
 ; Jupyter cell tag
 (
-  (comment) @name
-  (#match? @name "^#\\s?%%")
+    (comment) @name
+    (#match? @name "^#\\s?%%")
 ) @item

--- a/languages/r/textobjects.scm
+++ b/languages/r/textobjects.scm
@@ -1,122 +1,122 @@
-; block
-; call
-(call) @call.outer
+; ; block
+; ; call
+; (call) @call.outer
 
-(arguments) @call.inner
+; (arguments) @call.inner
 
-; class
-; comment
-(comment) @comment.outer
+; ; class
+; ; comment
+; (comment) @comment.outer
 
-; conditional
-(if
-  condition: (_)? @conditional.inner) @conditional.outer
+; ; conditional
+; (if
+;   condition: (_)? @conditional.inner) @conditional.outer
 
-; function
-[
-  (function_definition)
-  (lambda_function)
-] @function.outer
+; ; function
+; [
+;   (function_definition)
+;   (lambda_function)
+; ] @function.outer
 
-(function_definition
-  [
-    (call)
-    (binary)
-    (brace_list)
-  ] @function.inner) @function.outer
+; (function_definition
+;   [
+;     (call)
+;     (binary)
+;     (brace_list)
+;   ] @function.inner) @function.outer
 
-(lambda_function
-  [
-    (call)
-    (binary)
-    (brace_list)
-  ] @function.inner) @function.outer
+; (lambda_function
+;   [
+;     (call)
+;     (binary)
+;     (brace_list)
+;   ] @function.inner) @function.outer
 
-; loop
-[
-  (while)
-  (repeat)
-  (for)
-] @loop.outer
+; ; loop
+; [
+;   (while)
+;   (repeat)
+;   (for)
+; ] @loop.outer
 
-(while
-  body: (_) @loop.inner)
+; (while
+;   body: (_) @loop.inner)
 
-(repeat
-  body: (_) @loop.inner)
+; (repeat
+;   body: (_) @loop.inner)
 
-(for
-  body: (_) @loop.inner)
+; (for
+;   body: (_) @loop.inner)
 
-; statement
-(brace_list
-  (_) @statement.outer)
+; ; statement
+; (brace_list
+;   (_) @statement.outer)
 
-(program
-  (_) @statement.outer)
+; (program
+;   (_) @statement.outer)
 
-; parameter
-((formal_parameters
-  "," @_start
-  .
-  (_) @parameter.inner)
-  (#make-range! "parameter.outer" @_start @parameter.inner))
+; ; parameter
+; ((formal_parameters
+;   "," @_start
+;   .
+;   (_) @parameter.inner)
+;   (#make-range! "parameter.outer" @_start @parameter.inner))
 
-((formal_parameters
-  .
-  (_) @parameter.inner
-  .
-  ","? @_end)
-  (#make-range! "parameter.outer" @parameter.inner @_end))
+; ((formal_parameters
+;   .
+;   (_) @parameter.inner
+;   .
+;   ","? @_end)
+;   (#make-range! "parameter.outer" @parameter.inner @_end))
 
-((arguments
-  "," @_start
-  .
-  (_) @parameter.inner)
-  (#make-range! "parameter.outer" @_start @parameter.inner))
+; ((arguments
+;   "," @_start
+;   .
+;   (_) @parameter.inner)
+;   (#make-range! "parameter.outer" @_start @parameter.inner))
 
-((arguments
-  .
-  (_) @parameter.inner
-  .
-  ","? @_end)
-  (#make-range! "parameter.outer" @parameter.inner @_end))
+; ((arguments
+;   .
+;   (_) @parameter.inner
+;   .
+;   ","? @_end)
+;   (#make-range! "parameter.outer" @parameter.inner @_end))
 
-; number
-(float) @number.inner
+; ; number
+; (float) @number.inner
 
-; assignment
-(left_assignment
-  name: (_) @assignment.lhs
-  value: (_) @assignment.inner @assignment.rhs) @assignment.outer
+; ; assignment
+; (left_assignment
+;   name: (_) @assignment.lhs
+;   value: (_) @assignment.inner @assignment.rhs) @assignment.outer
 
-(left_assignment
-  name: (_) @assignment.inner)
+; (left_assignment
+;   name: (_) @assignment.inner)
 
-(right_assignment
-  value: (_) @assignment.inner @assignment.lhs
-  name: (_) @assignment.rhs) @assignment.outer
+; (right_assignment
+;   value: (_) @assignment.inner @assignment.lhs
+;   name: (_) @assignment.rhs) @assignment.outer
 
-(right_assignment
-  name: (_) @assignment.inner)
+; (right_assignment
+;   name: (_) @assignment.inner)
 
-(equals_assignment
-  name: (_) @assignment.lhs
-  value: (_) @assignment.inner @assignment.rhs) @assignment.outer
+; (equals_assignment
+;   name: (_) @assignment.lhs
+;   value: (_) @assignment.inner @assignment.rhs) @assignment.outer
 
-(equals_assignment
-  name: (_) @assignment.inner)
+; (equals_assignment
+;   name: (_) @assignment.inner)
 
-(super_assignment
-  name: (_) @assignment.lhs
-  value: (_) @assignment.inner @assignment.rhs) @assignment.outer
+; (super_assignment
+;   name: (_) @assignment.lhs
+;   value: (_) @assignment.inner @assignment.rhs) @assignment.outer
 
-(super_assignment
-  name: (_) @assignment.inner)
+; (super_assignment
+;   name: (_) @assignment.inner)
 
-(super_right_assignment
-  value: (_) @assignment.inner @assignment.lhs
-  name: (_) @assignment.rhs) @assignment.outer
+; (super_right_assignment
+;   value: (_) @assignment.inner @assignment.lhs
+;   name: (_) @assignment.rhs) @assignment.outer
 
-(super_right_assignment
-  name: (_) @assignment.inner)
+; (super_right_assignment
+;   name: (_) @assignment.inner)


### PR DESCRIPTION
- Used the latest commit in [tree-sitter-r](https://github.com/r-lib/tree-sitter-r) but changed some lines in `highlighting.scm`
- There is an issue in `switch` not being recognized as a keyword as it breaks the extension
- ~~Couldn't implement the newer `outline.scm` from `locals.scm` and `tags.scm` from tree-sitter-r~~ Implemented the new `outline.scm`
- The newer `outline.scm` should be edited in order to integrate with Zed's captures, for now the outline panel only has REPL cells listed.
- Didn't understand the purpose from the existing `textobjects.scm` file and it breaks the extension ~~alongside the old `outline.scm`~~ so it's commented out for now.