### PR TITLE
Small amends for the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The R packages 'languageserver' and 'lintr' are needed
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-f10": "repl::Restart", # Equivalent to restarting R in RStudio
+      "ctrl-shift-f10": "repl::Restart", // Equivalent to restarting R in RStudio
       "ctrl-\\": "assistant::InlineAssist",
       "ctrl-shift-m": ["workspace::SendKeystrokes", "space |> space"],
       "alt--": ["workspace::SendKeystrokes", "space < - space"],

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The R packages 'languageserver' and 'lintr' are needed
 
   - Add this to your keymap.json by opening the command palette (Ctrl+Shift+P) and selecting `zed: open keymap`. Note in the following that users on macOS will likely want to replace `ctrl` with `cmd`.
 
-```
+```json
   {
     "context": "Editor",
     "bindings": {
@@ -59,7 +59,7 @@ The R packages 'languageserver' and 'lintr' are needed
 
   - Add this to your tasks.json by opening the command palette (Ctrl+Shift+P) and selecting `zed: open tasks`
 
-```
+```json
 [
   {
     "label": "R Terminal",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The R packages 'languageserver' and 'lintr' are needed
 
 # RStudio keybindings
 
-  - Add this to your keymap.json by opening the command palette (Ctrl+Shift+P) and selecting `zed: open keymap`.
+  - Add this to your keymap.json by opening the command palette (Ctrl+Shift+P) and selecting `zed: open keymap`. Note in the following that users on macOS will likely want to replace `ctrl` with `cmd`.
 
 ```
   {

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The R packages 'languageserver' and 'lintr' are needed
 
 # RStudio keybindings
 
-  - Add this to your keybindings.json by opening the command palette (Ctrl+Shift+P) and selecting `zed: open keybindings`
+  - Add this to your keymap.json by opening the command palette (Ctrl+Shift+P) and selecting `zed: open keymap`.
 
 ```
   {


### PR DESCRIPTION
The commit messages should be explanatory, in this:

- keybindings.json now seems to be keymap.json
- an incorrect comment symbol was used in the first json chunk, I have amended `#` to `//`
- added a comment that macOS users likely want to use `cmd` instead of `ctrl` for the shortcuts
- added json language to the code chunks for GitHub syntax highlighting