### PR TITLE
Add a few more shortcuts and tasks to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ The R packages 'languageserver' and 'lintr' are needed
       "cmd-shift-enter": [
         "task::Spawn",
         { "task_name": "Source current file", "reveal_target": "dock"}
+      ],
+      "ctrl-shift-e": [
+        "task::Spawn",
+        { "task_name": "Check local R package", "reveal_target": "dock"}
       ]
     }
   }
@@ -135,6 +139,13 @@ The R packages 'languageserver' and 'lintr' are needed
     "reveal": "always",
     "show_summary": true,
     "show_output": true
+  },
+  {
+    "label": "Check local R package",
+    "command": "Rscript -e \"devtools::check()\"",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ The R packages 'languageserver' and 'lintr' are needed
       "ctrl-2": [
         "task::Spawn",
         { "task_name": "R Terminal", "reveal_target": "dock" }
+      ],
+      "cmd-shift-enter": [
+        "task::Spawn",
+        { "task_name": "Source current file", "reveal_target": "dock"}
       ]
     }
   }
@@ -121,6 +125,16 @@ The R packages 'languageserver' and 'lintr' are needed
       "\"testthat::test_file(\\\"${ZED_FILE}\\\", desc = \\\"${ZED_CUSTOM_desc}\\\")\""
     ],
     "tags": ["r-test"]
+  },
+  {
+    "label": "Source current file",
+    "command": "Rscript -e \"source('$ZED_RELATIVE_FILE', echo = TRUE)\"",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "use_new_terminal": false,
+    "allow_concurrent_runs": false,
+    "reveal": "always",
+    "show_summary": true,
+    "show_output": true
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ The R packages 'languageserver' and 'lintr' are needed
 ```
 
   - For a different keyboard shortcut for tasks, follow [this section](https://zed.dev/docs/tasks#custom-keybindings-for-tasks) in the official Zed documentation.
+  
+  - Additionally it is possible to run R code using Zed's REPL feature. To enable this, install either the Ark or Xeus Jupyter kernels and then in an R file run a line or selection by pressing `ctrl-shift-enter`. The documentation can be found at
+    - https://zed.dev/docs/languages/r
+    - https://zed.dev/docs/repl
+    - https://zed.dev/docs/repl#r-ark
+    - https://zed.dev/docs/repl#r-xeus
 
 # Caveats
   - A custom startup message in `.Rprofile` can potentially cause the the LSP message headers to be decoded improperly and prevent the language server from starting in Zed ([#7](https://github.com/ocsmit/zed-r/issues/7)).

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The R packages 'languageserver' and 'lintr' are needed
       "ctrl-shift-d": [
         "task::Spawn",
         { "task_name": "Document local R package", "reveal_target": "center" }
+      ],
+      "ctrl-alt-enter": [
+        "workspace::SendKeystrokes",
+        "ctrl-c ctrl-` ctrl-v enter ctrl-` down"
       ]
     }
   },
@@ -51,7 +55,7 @@ The R packages 'languageserver' and 'lintr' are needed
       ],
       "ctrl-2": [
         "task::Spawn",
-        { "task_name": "R Terminal", "reveal_target": "center" }
+        { "task_name": "R Terminal", "reveal_target": "dock" }
       ]
     }
   }


### PR DESCRIPTION
This adds to the README

- `ctrl-alt-enter` for sending current line/selection to (an R) terminal in the Zed Dock - this is an alternative to running R code in the Zed REPL. I'm on a Mac so have this at `cmd-alt-enter`. Of course RStudio is simply `cmd-enter` but that didn't seem to work. I seemed to have to move the Zed R Terminal from `"center"` to `"dock"` to get this to work. Also Mac users need to change the `ctrl-c` and `ctrl-v` in this to `cmd-c` and `cmd-v`.
- `cmd-shift-enter` for sourcing the current R file - I left this as the Mac shortcut because the REPL is `ctrl-shift-enter` on Mac (not sure if it is on Linux)
- `ctrl-shift-e` for running R CMD check on a local package
- a comment about using the Zed REPL and the Jupyter kernels to run R code.