### PR TITLE
Bump Zed extension API to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ path = "src/r.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.3.0"
+zed_extension_api = "0.4.0"

--- a/languages/r/config.toml
+++ b/languages/r/config.toml
@@ -2,6 +2,7 @@ name = "R"
 grammar = "r"
 path_suffixes = ["r", "R"]
 line_comments = ["# ", "#' "]
+tab_size = 2
 autoclose_before = "$@=,}])"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
Hey there,

I see in the 0.184.x release, which just came out, Zed have bumped their extension API again - <https://github.com/zed-industries/zed/pull/29237>.

I don't actually know what the differences are between the API versions - but I guess it makes sense to keep on latest.